### PR TITLE
Fixes race condition that would cause the GATT connection to halt if characteristic callback is called before the deferred is added to the Map

### DIFF
--- a/src/main/java/betterbluetoothle/async/AsyncBluetoothGatt.java
+++ b/src/main/java/betterbluetoothle/async/AsyncBluetoothGatt.java
@@ -288,10 +288,11 @@ public class AsyncBluetoothGatt extends BluetoothGattCallback {
         }
         // Read descriptor and return a promise for the results.
         deferred = new DeferredObject<BluetoothGattCharacteristic, Integer, Void>();
+        readCharacteristic.put(new CharacteristicKey(characteristic), deferred);
+
         if (!gatt.readCharacteristic(characteristic)) {
             deferred.reject(null);
         }
-        readCharacteristic.put(new CharacteristicKey(characteristic), deferred);
         return deferred.promise();
     }
 
@@ -305,10 +306,11 @@ public class AsyncBluetoothGatt extends BluetoothGattCallback {
         }
         // Read descriptor and return a promise for the results.
         deferred = new DeferredObject<BluetoothGattCharacteristic, Integer, Void>();
+        writeCharacteristic.put(new CharacteristicKey(characteristic), deferred);
+
         if (!gatt.writeCharacteristic(characteristic)) {
             deferred.reject(null);
         }
-        writeCharacteristic.put(new CharacteristicKey(characteristic), deferred);
         return deferred.promise();
     }
 
@@ -344,10 +346,11 @@ public class AsyncBluetoothGatt extends BluetoothGattCallback {
         else if (enable) {
             // Setup and return the deferred for receiving progress of notification changes.
             deferred = new DeferredObject<Void, Void, BluetoothGattCharacteristic>();
+            changeCharacteristic.put(new CharacteristicKey(characteristic), deferred);
+            
             if (!gatt.setCharacteristicNotification(characteristic, true)) {
                 deferred.reject(null);
             }
-            changeCharacteristic.put(new CharacteristicKey(characteristic), deferred);
             return deferred.promise();
         }
         // Ignore disabling a notification that isn't enabled.


### PR DESCRIPTION
Sometimes, because the GATT call (i.e. `writeCharacteristic`, `readCharacteristic`) is made before adding the deferred object to the respective Map, the `onCharacteristicRead`, `onCharacteristicWrite` or `onCharacteristicChanged` callbacks could be called from another thread before the DeferredObject was added to the map.

```
deferred = new DeferredObject<BluetoothGattCharacteristic, Integer, Void>();
if (!gatt.writeCharacteristic(characteristic)) {
    deferred.reject(null);
}
writeCharacteristic.put(new CharacteristicKey(characteristic), deferred);
return deferred.promise();
```

This would result in a state where one of those callbacks would be executed when an old, already finished DeferredObject would be present in the Map, instead of the newly created object.

On `onCharacteristicWrite`, for instance:
```
DeferredObject<BluetoothGattCharacteristic, Integer, Void> deferred = writeCharacteristic.get(new CharacteristicKey(characteristic));
if (deferred != null) {
    // Resolve or reject the deferred based on success or failure of the characteristic write.
    if (status == BluetoothGatt.GATT_SUCCESS) {
        deferred.resolve(characteristic);
    }
    else {
        deferred.reject(status);
     }
 }
```

Since `deferred` was originally created for a past `writeCharacteristic` call, it would have already been resolved or rejected. Calling `deferred.resolve` would throw an exception:

In `DeferredObject.resolve`:
```
if (!isPending())
    throw new IllegalStateException("Deferred object already finished, cannot resolve again");
```

Fixed this by moving the `writeCharacteristic.put(new CharacteristicKey(characteristic), deferred);` line to before the GATT call is made.